### PR TITLE
feat: add option to ignore unmappable messages

### DIFF
--- a/app/src/main/java/dev/pcvolkmer/onco/obds2toobds3/Application.java
+++ b/app/src/main/java/dev/pcvolkmer/onco/obds2toobds3/Application.java
@@ -19,6 +19,8 @@ public class Application {
         options.addOption(
                 Option.builder("o").argName("output").hasArg().desc("Output file").converter(File::new).build());
         options.addOption(
+                Option.builder("ignore-unmappable-messages").desc("Ugnore unmappable messages").build());
+        options.addOption(
                 Option.builder("v").desc("Show errors").build());
         options.addOption(
                 Option.builder("vv").desc("Show exceptions and stack traces").build());
@@ -32,7 +34,9 @@ public class Application {
                 var input = Paths.get(parsedCliArgs.getOptionValue("i"));
                 var output = Paths.get(parsedCliArgs.getOptionValue("o"));
 
-                var mapper = new ObdsMapper();
+                var mapper = ObdsMapper.builder()
+                        .ignoreUnmappableMessages(parsedCliArgs.hasOption("ignore-unmappable-messages"))
+                        .build();
                 var bomInputStream = BOMInputStream.builder().setInputStream(Files.newInputStream(input)).get();
 
                 var inputObj = mapper.readValue(IOUtils.toString(bomInputStream, StandardCharsets.UTF_8),

--- a/app/src/main/java/dev/pcvolkmer/onco/obds2toobds3/Application.java
+++ b/app/src/main/java/dev/pcvolkmer/onco/obds2toobds3/Application.java
@@ -19,7 +19,7 @@ public class Application {
         options.addOption(
                 Option.builder("o").argName("output").hasArg().desc("Output file").converter(File::new).build());
         options.addOption(
-                Option.builder("ignore-unmappable-messages").desc("Ugnore unmappable messages").build());
+                Option.builder("ignore-unmappable-messages").desc("Ignore unmappable messages").build());
         options.addOption(
                 Option.builder("v").desc("Show errors").build());
         options.addOption(

--- a/lib/src/main/java/dev/pcvolkmer/onko/obds2to3/MeldungMapper.java
+++ b/lib/src/main/java/dev/pcvolkmer/onko/obds2to3/MeldungMapper.java
@@ -29,26 +29,38 @@ import de.basisdatensatz.obds.v3.*;
 import de.basisdatensatz.obds.v3.DiagnoseTyp.MengeFruehereTumorerkrankung.FruehereTumorerkrankung;
 import de.basisdatensatz.obds.v3.OBDS.MengePatient.Patient.MengeMeldung.Meldung;
 
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 class MeldungMapper {
 
     private static final String MUST_NOT_BE_NULL = "ADT_GEKID must not be null at this point";
     private static final String DIAGNOSE_SHOULD_NOT_BE_NULL = "ADT_GEKID diagnose should not be null at this point";
+    private static final String TUMORZUORDUNG_SHOULD_NOT_BE_NULL = "ADT_GEKID tumorzuordung should not be null at this point - required for oBDS v3";
 
-    private MeldungMapper() {}
+    private final boolean ignoreUnmappableMessages;
+
+    MeldungMapper(boolean ignoreUnmappableMessages) {
+        this.ignoreUnmappableMessages = ignoreUnmappableMessages;
+    }
 
     /**
      * Mappe eine ADT_GEKID oBDS v2 Meldung in eine Liste von oBDS v3 Meldungen
      *
-     * @param source
+     * @param source The source message
      * @return
      */
-    public static List<Meldung> map(ADTGEKID.MengePatient.Patient.MengeMeldung.Meldung source) {
+    public List<Meldung> map(ADTGEKID.MengePatient.Patient.MengeMeldung.Meldung source) {
+        if (null == source) {
+            throw new IllegalArgumentException(MUST_NOT_BE_NULL);
+        }
+
+        if (null == source.getTumorzuordnung()) {
+            if (ignoreUnmappableMessages) {
+                return new ArrayList<>();
+            }
+            throw new UnmappableItemException(TUMORZUORDUNG_SHOULD_NOT_BE_NULL);
+        }
+
         var result = new ArrayList<Meldung>();
         // Diagnose als einzelne Meldung
         var diagnosemeldung = getMeldungDiagnose(source);

--- a/lib/src/main/java/dev/pcvolkmer/onko/obds2to3/ObdsMapper.java
+++ b/lib/src/main/java/dev/pcvolkmer/onko/obds2to3/ObdsMapper.java
@@ -39,8 +39,9 @@ import java.util.Optional;
 public class ObdsMapper {
 
     private final XmlMapper mapper;
+    private final PatientMapper patientMapper;
 
-    public ObdsMapper() {
+    private ObdsMapper(boolean ignoreUnmappableMessages) {
         mapper = XmlMapper.builder()
                 .defaultUseWrapper(false)
                 .defaultDateFormat(new SimpleDateFormat("yyyy-MM-dd"))
@@ -49,6 +50,11 @@ public class ObdsMapper {
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .serializationInclusion(JsonInclude.Include.NON_EMPTY)
                 .build();
+        patientMapper = new PatientMapper(ignoreUnmappableMessages);
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     public OBDS map(ADTGEKID adtgekid) {
@@ -84,7 +90,7 @@ public class ObdsMapper {
         assert mengePatient != null;
 
         var mappedMengePatient = new OBDS.MengePatient();
-        mappedMengePatient.getPatient().addAll(mengePatient.getPatient().stream().map(PatientMapper::map).toList());
+        mappedMengePatient.getPatient().addAll(mengePatient.getPatient().stream().map(patientMapper::map).toList());
         obds.setMengePatient(mappedMengePatient);
 
         // Menge Melder
@@ -128,4 +134,16 @@ public class ObdsMapper {
         throw new SchemaValidatorException("Cannot validate result using oBDS schema");
     }
 
+    public static class Builder {
+        private boolean ignoreUnmappableMessages;
+
+        public Builder ignoreUnmappableMessages(boolean ignoreUnmappableMessages) {
+            this.ignoreUnmappableMessages = ignoreUnmappableMessages;
+            return this;
+        }
+
+        public ObdsMapper build() {
+            return new ObdsMapper(ignoreUnmappableMessages);
+        }
+    }
 }

--- a/lib/src/main/java/dev/pcvolkmer/onko/obds2to3/PatientMapper.java
+++ b/lib/src/main/java/dev/pcvolkmer/onko/obds2to3/PatientMapper.java
@@ -36,10 +36,13 @@ import java.util.Objects;
 
 class PatientMapper {
 
-    private PatientMapper() {
+    private final MeldungMapper meldungMapper;
+
+    PatientMapper(boolean ignoreUnmappableMessages) {
+        this.meldungMapper = new MeldungMapper(ignoreUnmappableMessages);
     }
 
-    public static OBDS.MengePatient.Patient map(ADTGEKID.MengePatient.Patient source) {
+    public OBDS.MengePatient.Patient map(ADTGEKID.MengePatient.Patient source) {
         if (null == source) {
             throw new IllegalArgumentException("Source cannot be null");
         }
@@ -55,7 +58,7 @@ class PatientMapper {
 
         // Meldungen
         var mappedMeldungen = source.getMengeMeldung().getMeldung().stream()
-                .map(MeldungMapper::map)
+                .map(meldungMapper::map)
                 .flatMap(List::stream)
                 .toList();
 

--- a/lib/src/main/java/dev/pcvolkmer/onko/obds2to3/UnmappableItemException.java
+++ b/lib/src/main/java/dev/pcvolkmer/onko/obds2to3/UnmappableItemException.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of obds2-to-obds3
+ *
+ * Copyright (c) 2025 the original author or authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.pcvolkmer.onko.obds2to3;
+
+public class UnmappableItemException extends RuntimeException {
+    public UnmappableItemException(String message) {
+        super(message);
+    }
+
+    public UnmappableItemException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/lib/src/test/resources/testdaten/obdsv2_keine-tumorzuordung.xml
+++ b/lib/src/test/resources/testdaten/obdsv2_keine-tumorzuordung.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ADT_GEKID xmlns="http://www.gekid.de/namespace" Schema_Version="2.2.3">
+  <Absender Absender_ID="TEST" Software_ID="ONKOSTAR" Installations_ID="2011">
+    <Absender_Bezeichnung>TEST</Absender_Bezeichnung>
+    <Absender_Anschrift>Musterstraße 1, 012345 Musterhausen</Absender_Anschrift>
+  </Absender>
+  <Menge_Patient>
+    <Patient>
+      <Patienten_Stammdaten Patient_ID="20001234">
+        <KrankenversichertenNr>E123456789</KrankenversichertenNr>
+        <KrankenkassenNr>103456789</KrankenkassenNr>
+        <Patienten_Nachname>Tester</Patienten_Nachname>
+        <Patienten_Titel />
+        <Patienten_Vornamen>Patrick</Patienten_Vornamen>
+        <Patienten_Geburtsname>Tester</Patienten_Geburtsname>
+        <Menge_Frueherer_Name>
+          <Patienten_Frueherer_Name>Klaus Pimpelhuber</Patienten_Frueherer_Name>
+        </Menge_Frueherer_Name>
+        <Patienten_Geschlecht>M</Patienten_Geschlecht>
+        <Patienten_Geburtsdatum>01.01.1980</Patienten_Geburtsdatum>
+        <Menge_Adresse>
+          <Adresse>
+            <Patienten_Strasse>Testweg</Patienten_Strasse>
+            <Patienten_Hausnummer>1</Patienten_Hausnummer>
+            <Patienten_Land>DE</Patienten_Land>
+            <Patienten_PLZ>01234</Patienten_PLZ>
+            <Patienten_Ort>Musterhausen</Patienten_Ort>
+          </Adresse>
+        </Menge_Adresse>
+      </Patienten_Stammdaten>
+      <Menge_Meldung>
+        <Meldung Meldung_ID="TEST1727528-1" Melder_ID="TEST">
+          <Meldedatum>11.06.2024</Meldedatum>
+          <Meldebegruendung>I</Meldebegruendung>
+          <Meldeanlass>diagnose</Meldeanlass>
+          <Tumorzuordnung Tumor_ID="1">
+            <Primaertumor_ICD_Code>C17.1</Primaertumor_ICD_Code>
+            <Primaertumor_ICD_Version>10 2015 GM</Primaertumor_ICD_Version>
+            <Diagnosedatum>10.06.2024</Diagnosedatum>
+            <Seitenlokalisation>T</Seitenlokalisation>
+          </Tumorzuordnung>
+          <Diagnose>
+            <Diagnosesicherung>1</Diagnosesicherung>
+            <Allgemeiner_Leistungszustand>0</Allgemeiner_Leistungszustand>
+            <Anmerkung>Test</Anmerkung>
+          </Diagnose>
+        </Meldung>
+        <Meldung Meldung_ID="TEST1727528-2" Melder_ID="TEST">
+          <Meldedatum>11.06.2024</Meldedatum>
+          <Meldebegruendung>I</Meldebegruendung>
+          <Meldeanlass>statusaenderung</Meldeanlass>
+          <Diagnose>
+            <Diagnosesicherung>1</Diagnosesicherung>
+            <Allgemeiner_Leistungszustand>0</Allgemeiner_Leistungszustand>
+            <Anmerkung>Test</Anmerkung>
+          </Diagnose>
+        </Meldung>
+      </Menge_Meldung>
+    </Patient>
+  </Menge_Patient>
+  <Menge_Melder>
+    <Melder Melder_ID="TEST">
+      <Melder_IKNR>103456789</Melder_IKNR>
+      <Meldende_Stelle>TEST</Meldende_Stelle>
+    </Melder>
+  </Menge_Melder>
+</ADT_GEKID>

--- a/lib/src/test/resources/testdaten/obdsv3_keine-tumorzuordung.xml
+++ b/lib/src/test/resources/testdaten/obdsv3_keine-tumorzuordung.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<oBDS xmlns="http://www.basisdatensatz.de/oBDS/XML" Schema_Version="3.0.3">
+  <Absender Absender_ID="TEST" Software_ID="obds2-to-obds3" Software_Version="0.1.0">
+    <Bezeichnung>TEST</Bezeichnung>
+    <Anschrift>Musterstraße 1, 012345 Musterhausen</Anschrift>
+  </Absender>
+  <Meldedatum>2024-06-11</Meldedatum>
+  <Menge_Patient>
+    <Patient Patient_ID="20001234">
+      <Patienten_Stammdaten>
+        <Versichertendaten_GKV>
+          <IKNR>103456789</IKNR>
+          <GKV_Versichertennummer>E123456789</GKV_Versichertennummer>
+        </Versichertendaten_GKV>
+        <Nachname>Tester</Nachname>
+        <Vornamen>Patrick</Vornamen>
+        <Geburtsname>Tester</Geburtsname>
+        <Menge_Frueherer_Name>
+          <Frueherer_Name>Klaus Pimpelhuber</Frueherer_Name>
+        </Menge_Frueherer_Name>
+        <Geschlecht>M</Geschlecht>
+        <Geburtsdatum Datumsgenauigkeit="E">1980-01-01</Geburtsdatum>
+        <Adresse>
+          <Strasse>Testweg</Strasse>
+          <Hausnummer>1</Hausnummer>
+          <Land>DE</Land>
+          <PLZ>01234</PLZ>
+          <Ort>Musterhausen</Ort>
+        </Adresse>
+      </Patienten_Stammdaten>
+      <Menge_Meldung>
+        <Meldung Meldung_ID="TEST1727528-1" Melder_ID="TEST">
+          <Meldebegruendung>I</Meldebegruendung>
+          <Eigene_Leistung>J</Eigene_Leistung>
+          <Tumorzuordnung Tumor_ID="1">
+            <Primaertumor_ICD>
+              <Code>C17.1</Code>
+              <Version>10 2015 GM</Version>
+            </Primaertumor_ICD>
+            <Diagnosedatum Datumsgenauigkeit="E">2024-06-10</Diagnosedatum>
+            <Seitenlokalisation>T</Seitenlokalisation>
+          </Tumorzuordnung>
+          <Diagnose>
+            <Diagnosesicherung>1</Diagnosesicherung>
+            <Allgemeiner_Leistungszustand>0</Allgemeiner_Leistungszustand>
+          </Diagnose>
+        </Meldung>
+      </Menge_Meldung>
+    </Patient>
+  </Menge_Patient>
+  <Menge_Melder>
+    <Melder ID="TEST">
+      <Ident_Nummern>
+        <IKNR>103456789</IKNR>
+      </Ident_Nummern>
+    </Melder>
+  </Menge_Melder>
+</oBDS>


### PR DESCRIPTION
Since some ADT_GEKID messages dit not contain all required information to be mapped into oBDS v3, there should be an option to simply skip/ignore those messages instead of failing to map all input data.