### PR TITLE
chore: use X or U if no Verlauf_Tumorstatus mapping possible

### DIFF
--- a/lib/src/main/java/dev/pcvolkmer/onko/obds2to3/MeldungMapper.java
+++ b/lib/src/main/java/dev/pcvolkmer/onko/obds2to3/MeldungMapper.java
@@ -400,7 +400,17 @@ class MeldungMapper {
                     // oBDS v2 Meldung->Meldeanlass wird in oBDS v3 für Verlauf verwendet
                     mappedVerlauf.setMeldeanlass(source.getMeldeanlass());
                     mappedVerlauf.setVerlaufLokalerTumorstatus(verlauf.getVerlaufLokalerTumorstatus());
-                    mappedVerlauf.setVerlaufTumorstatusFernmetastasen(verlauf.getVerlaufTumorstatusFernmetastasen());
+
+                    if (null == verlauf.getVerlaufTumorstatusFernmetastasen()) {
+                        // Keine Angabe, daher "X" - keine Angabe
+                        mappedVerlauf.setVerlaufTumorstatusFernmetastasen("X");
+                    } else if ("M".equals(verlauf.getVerlaufTumorstatusFernmetastasen())) {
+                        // "M" ist nicht mehr in oBDS3 enthalten. Kein genaues Mapping möglich, daher "U" - unbekannt
+                        mappedVerlauf.setVerlaufTumorstatusFernmetastasen("U");
+                    } else {
+                        mappedVerlauf.setVerlaufTumorstatusFernmetastasen(verlauf.getVerlaufTumorstatusFernmetastasen());
+                    }
+
                     mappedVerlauf.setVerlaufTumorstatusLymphknoten(verlauf.getVerlaufTumorstatusLymphknoten());
 
                     mapHistologie(verlauf.getHistologie()).ifPresent(mappedVerlauf::setHistologie);

--- a/lib/src/test/resources/testdaten/obdsv3_keine-diagnose.xml
+++ b/lib/src/test/resources/testdaten/obdsv3_keine-diagnose.xml
@@ -39,6 +39,7 @@
             <Meldeanlass>statusaenderung</Meldeanlass>
             <Untersuchungsdatum_Verlauf>2017-11-06</Untersuchungsdatum_Verlauf>
             <Gesamtbeurteilung_Tumorstatus>K</Gesamtbeurteilung_Tumorstatus>
+            <Verlauf_Tumorstatus_Fernmetastasen>X</Verlauf_Tumorstatus_Fernmetastasen>
             <Allgemeiner_Leistungszustand>0</Allgemeiner_Leistungszustand>
           </Verlauf>
         </Meldung>

--- a/lib/src/test/resources/testdaten/obdsv3_verlauf.xml
+++ b/lib/src/test/resources/testdaten/obdsv3_verlauf.xml
@@ -60,6 +60,7 @@
             <Meldeanlass>statusaenderung</Meldeanlass>
             <Untersuchungsdatum_Verlauf>2024-10-14</Untersuchungsdatum_Verlauf>
             <Gesamtbeurteilung_Tumorstatus>B</Gesamtbeurteilung_Tumorstatus>
+            <Verlauf_Tumorstatus_Fernmetastasen>X</Verlauf_Tumorstatus_Fernmetastasen>
             <Allgemeiner_Leistungszustand>1</Allgemeiner_Leistungszustand>
           </Verlauf>
         </Meldung>
@@ -78,6 +79,7 @@
             <Meldeanlass>statusaenderung</Meldeanlass>
             <Untersuchungsdatum_Verlauf>2024-10-15</Untersuchungsdatum_Verlauf>
             <Gesamtbeurteilung_Tumorstatus>B</Gesamtbeurteilung_Tumorstatus>
+            <Verlauf_Tumorstatus_Fernmetastasen>X</Verlauf_Tumorstatus_Fernmetastasen>
             <Allgemeiner_Leistungszustand>1</Allgemeiner_Leistungszustand>
           </Verlauf>
         </Meldung>


### PR DESCRIPTION
"X" - no value given
"M" - does not exist in oBDS3, use "U" (unknown) instead since no exact mapping is possible.