### PR TITLE
fix: only log if multiple entries for 'Diagnose.Histologie' are found that differ in content

### DIFF
--- a/lib/src/main/java/io/github/bzkf/obds2toobds3/MeldungMapper.java
+++ b/lib/src/main/java/io/github/bzkf/obds2toobds3/MeldungMapper.java
@@ -615,8 +615,26 @@ class MeldungMapper {
     if (diagnose.getMengeHistologie() != null) {
 
       if (diagnose.getMengeHistologie().getHistologie().size() > 1) {
-        LOG.warn(
-            "Multiple entries for 'Diagnose.Histologie' found. Only the first entry can be mapped!");
+        var allSame =
+            diagnose.getMengeHistologie().getHistologie().stream()
+                    .map(
+                        h -> {
+                          try {
+                            return ObdsMapper.XML_MAPPER.writeValueAsString(h);
+                          } catch (JsonProcessingException e) {
+                            LOG.error("Failed to serialize Histologie for comparison", e);
+                            return "";
+                          }
+                        })
+                    .distinct()
+                    .count()
+                == 1;
+        if (!allSame) {
+          LOG.warn(
+              "Multiple entries for 'Diagnose.Histologie' found that differ in content. "
+                  + "Only the first entry can be mapped! Meldung: {}",
+              source.getMeldungID());
+        }
       }
 
       var firstHistologie = diagnose.getMengeHistologie().getHistologie().stream().findFirst();

--- a/lib/src/test/resources/testdaten/obdsv2_histologie.xml
+++ b/lib/src/test/resources/testdaten/obdsv2_histologie.xml
@@ -48,6 +48,11 @@
                 <Histologie_EinsendeNr>T/2024/1234</Histologie_EinsendeNr>
                 <Grading>U</Grading>
               </Histologie>
+              <Histologie>
+                <Tumor_Histologiedatum>04.12.2024</Tumor_Histologiedatum>
+                <Histologie_EinsendeNr>T/2024/1234</Histologie_EinsendeNr>
+                <Grading>T</Grading>
+              </Histologie>
             </Menge_Histologie>
             <Anmerkung>Test</Anmerkung>
           </Diagnose>


### PR DESCRIPTION
closes #109 